### PR TITLE
removes reference to Header component not built and use of withHoC

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,3 @@
-import Header from '../components/header';
 import withMui from '../shared/MUI/withMUI';
 
 const Index = ({ title = 'Hello from next.js' }) => 
@@ -6,5 +5,5 @@ const Index = ({ title = 'Hello from next.js' }) =>
         <h2>{title}</h2>
     </div>;
 
-export default withMui(Index);
+export default Index;
 


### PR DESCRIPTION
This branch wasn't working because of the header component added when it was yet to be built (in next lesson).

Wrapping the index component with the `withHoC` HoC broke the app at this stage too. 

Removed that code and it works!

![](https://media.giphy.com/media/3ohc1ePfj4kwPibxS0/giphy.gif)